### PR TITLE
Fixed -Os build with GCC 4.9

### DIFF
--- a/hardware.c
+++ b/hardware.c
@@ -168,7 +168,7 @@ bool checkUserCode(u32 usrAddr) {
 void jumpToUser(u32 usrAddr) {
     typedef void (*funcPtr)(void);
 
-    u32 jumpAddr = *(vu32 *)(usrAddr + 0x04); /* reset ptr in vector table */
+    vu32 jumpAddr = *(vu32 *)(usrAddr + 0x04); /* reset ptr in vector table */
     funcPtr usrMain = (funcPtr) jumpAddr;
 
     /* tear down all the dfu related setup */

--- a/usb.c
+++ b/usb.c
@@ -267,8 +267,8 @@ void usbReset(void) {
     _SetEPType(ENDP0, EP_CONTROL);
     _SetEPTxStatus(ENDP0, EP_TX_STALL);
 
-    _SetEPRxAddr(ENDP0, ENDP0_RXADDR);
-    _SetEPTxAddr(ENDP0, ENDP0_TXADDR);
+    SetEPRxAddr(ENDP0, ENDP0_RXADDR);
+    SetEPTxAddr(ENDP0, ENDP0_TXADDR);
 
     Clear_Status_Out(ENDP0);
 


### PR DESCRIPTION
I've tracked down the reason for not compiling with "-Os" on GCC 4.9. Can you please review my changes and pull them into your repository?
